### PR TITLE
Fix API issues with latest QMK version

### DIFF
--- a/firmware/QMK/VIAL_source/totem/keymaps/default/keymap.c
+++ b/firmware/QMK/VIAL_source/totem/keymaps/default/keymap.c
@@ -178,7 +178,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 } else {
                     keymap_config.swap_lctl_lgui = false; // ─── WIN
                 }
-                eeconfig_update_keymap(keymap_config.raw);
+                eeconfig_update_keymap(&keymap_config);
                 clear_keyboard(); // ──── clear to prevent stuck keys
                 return false;
             }

--- a/firmware/QMK/VIAL_source/totem/keymaps/vial/keymap.c
+++ b/firmware/QMK/VIAL_source/totem/keymaps/vial/keymap.c
@@ -215,7 +215,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 } else {
                     keymap_config.swap_lctl_lgui = false; // ─── WIN
                 }
-                eeconfig_update_keymap(keymap_config.raw);
+                eeconfig_update_keymap(&keymap_config);
                 clear_keyboard(); // ──── clear to prevent stuck keys
                 return false;
             }


### PR DESCRIPTION
A small pull request to fix the compile error mentioned in this issue:
Fixes: #59 

When using the latest QMK firmware version:
```
error: passing argument 1 of 'eeconfig_update_keymap' makes pointer from integer without a cast [-Wint-conversion]
```

Caused by the changes in the QMK firmware API:
- https://github.com/qmk/qmk_firmware/issues/25310


